### PR TITLE
Consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Set the status code and content-type header:
 ```javascript
 const router = (req, res) => {
   if (req.url === "/") {
-    res.writeHead(200, { "content-type": "text/html" });
+    res.writeHead(200, { "content-type": "text/plain" });
   }
 };
 ```
@@ -213,7 +213,7 @@ Finally, send the response with `.end()`:
 ```javascript
 const router = (req, res) => {
   if (req.url === "/") {
-    res.writeHead(200, { "content-type": "text/html" });
+    res.writeHead(200, { "content-type": "text/plain" });
     res.end("hello");
   }
 };

--- a/router.js
+++ b/router.js
@@ -1,8 +1,8 @@
 const router = (req, res) => {
-  if (req.url === "/") {
-    res.writeHead(200, { "content-type": "text/plain" });
-    res.end("Hello");
+  if (req.url === '/') {
+    res.writeHead(200, { 'content-type': 'text/plain' })
+    res.end('hello')
   }
-};
+}
 
-module.exports = router;
+module.exports = router

--- a/test.js
+++ b/test.js
@@ -1,21 +1,21 @@
-const test = require("tape");
-const supertest = require("supertest");
-const router = require("./router");
+const test = require('tape')
+const supertest = require('supertest')
+const router = require('./router')
 
-test("Initialise", t => {
-  let num = 2;
-  t.equal(num, 2, "Should return 2");
-  t.end();
-});
+test('Initialise', t => {
+  let num = 2
+  t.equal(num, 2, 'Should return 2')
+  t.end()
+})
 
-test("Home route", t => {
+test('Home route', t => {
   supertest(router)
-    .get("/")
+    .get('/')
     .expect(200)
-    .expect("Content-Type", "text/plain")
+    .expect('Content-Type', 'text/plain')
     .end((err, res) => {
-      t.error(err);
-      t.equal(res.text, "Hello");
-      t.end();
-    });
-});
+      t.error(err)
+      t.equal(res.text, 'hello')
+      t.end()
+    })
+})


### PR DESCRIPTION
As it stands if you copy the code directly from the README, tests don't pass when they should, because of a 'text/html' and 'text/plain' mismatch. This fixes that.

- make example supertest "text/plain" in both test and router files
- make text sent "hello" in solution files, as per the README